### PR TITLE
Add `python-interpreter.h`

### DIFF
--- a/python/src/python-interpreter.h
+++ b/python/src/python-interpreter.h
@@ -1,0 +1,12 @@
+#ifndef SHD_PYTHON_INTERPRETER_H_
+#define SHD_PYTHON_INTERPRETER_H_
+
+#include "Python.h"
+
+#ifdef __FreeBSD__
+#include <floatingpoint.h>
+#endif
+
+int python_main(int, char **);
+
+#endif /* SHD_PYTHON_INTERPRETER_H_ */


### PR DESCRIPTION
The header file I had created at first was this one:

```c
#ifndef SHD_PYTHON_INTERPRETER_H_
#define SHD_PYTHON_INTERPRETER_H_

int python_main(int argc, char **argv);

#endif /* SHD_PYTHON_INTERPRETER_H_ */
```

When you mentioned that it was lost, I tried to look into the vcs history and found `python-plugin.h`:

```c
/*
 * See LICENSE for licensing information
 */

#ifndef SHADOWPYTHON_H_
#define SHADOWPYTHON_H_

/* Needs to be first */
#include <Python.h>
#include <stdio.h>
#include <stdlib.h>

int python_main(int, char **);

#endif /* SHADOWPYTHON_H_ */
```

Looking at this header file and the contents of the current `python-plugin.c`, I believe that it once was what the current `python-interpreter.h` is now. I also noticed that there is no `python-plugin.h` in the current version, but as `make` does not complain, I am not sure if that is needed. If that is indeed needed, then we need to create one as well.

The file in this PR is what makes more sense to me so far. Let me know what you think!

Thanks @Javex!